### PR TITLE
Fix RPi misdetects by substring matching

### DIFF
--- a/lib/pinout/board.ex
+++ b/lib/pinout/board.ex
@@ -9,7 +9,7 @@ defmodule Pinout.Board do
   defstruct [:model_name, :art_template, :connectors_key, :board_name]
 
   @type t() :: %__MODULE__{
-          model_name: String.t(),
+          model_name: String.t() | Regex.t(),
           art_template: atom(),
           connectors_key: atom(),
           board_name: String.t()

--- a/lib/pinout/db.ex
+++ b/lib/pinout/db.ex
@@ -12,7 +12,7 @@ defmodule Pinout.DB do
   @spec lookup_name_by_model(String.t()) :: String.t()
   def lookup_name_by_model(model) do
     Enum.find_value(Boards.boards(), Boards.unknown_board_name(), fn x ->
-      if x.model_name == model do
+      if model =~ x.model_name do
         x.board_name
       end
     end)

--- a/lib/pinout/db/boards.ex
+++ b/lib/pinout/db/boards.ex
@@ -19,43 +19,43 @@ defmodule Pinout.DB.Boards do
   def boards() do
     [
       %Pinout.Board{
-        model_name: "Raspberry Pi 3 Model B Rev 1.2",
+        model_name: "Raspberry Pi 3 Model B Rev",
         art_template: :large_rpi,
         connectors_key: :rpi,
         board_name: "Raspberry Pi 3B"
       },
       %Pinout.Board{
-        model_name: "Raspberry Pi 3 Model B Plus Rev 1.3",
+        model_name: "Raspberry Pi 3 Model B Plus Rev",
         art_template: :large_rpi,
         connectors_key: :rpi,
         board_name: "Raspberry Pi 3B+"
       },
       %Pinout.Board{
-        model_name: "Raspberry Pi 4 Model B Rev 1.1",
+        model_name: "Raspberry Pi 4 Model B Rev",
         art_template: :large_rpi,
         connectors_key: :rpi,
         board_name: "Raspberry Pi 4B"
       },
       %Pinout.Board{
-        model_name: "Raspberry Pi 5 Model B Rev 1.0",
+        model_name: "Raspberry Pi 5 Model B Rev",
         art_template: :large_rpi,
         connectors_key: :rpi,
         board_name: "Raspberry Pi 5B"
       },
       %Pinout.Board{
-        model_name: "Raspberry Pi 2 Model B Rev 1.1",
+        model_name: "Raspberry Pi 2 Model B Rev",
         art_template: :large_rpi,
         connectors_key: :rpi,
         board_name: "Raspberry Pi 2B"
       },
       %Pinout.Board{
-        model_name: "Raspberry Pi Zero 2 W Rev 1.0",
+        model_name: "Raspberry Pi Zero 2 W Rev",
         art_template: :small_rpi,
         connectors_key: :rpi,
         board_name: "Raspberry Pi Zero 2 W"
       },
       %Pinout.Board{
-        model_name: "Raspberry Pi Zero W Rev 1.1",
+        model_name: "Raspberry Pi Zero W Rev",
         art_template: :small_rpi,
         connectors_key: :rpi,
         board_name: "Raspberry Pi Zero W"
@@ -67,7 +67,7 @@ defmodule Pinout.DB.Boards do
         board_name: "PocketBeagle"
       },
       %Pinout.Board{
-        model_name: "Raspberry Pi 400 Rev 1.0",
+        model_name: "Raspberry Pi 400 Rev",
         art_template: :rpi_400,
         connectors_key: :rpi,
         board_name: "Raspberry Pi 400"


### PR DESCRIPTION
This switches the matches to use `=~` for string matching to not require
such precise board name strings. This really helps the Raspberry Pis
which include a board revision in their strings. A newer Pi4 was failing
to match, and I suspect that others might have failed without this too.
